### PR TITLE
Update project to Java 21 and Spring Boot 4.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
       - name: Cache SonarQube packages
         uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:21-jdk-alpine
 
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
     <version>1.0.0</version>
     <packaging>war</packaging>
     <name>Simple-Invoicing</name>
-    <description>Final Project — Spring Boot Advanced — May 2024</description>
+    <description>Final Project – Spring Boot Advanced – May 2024</description>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
-        <spring-boot.version>3.5.7</spring-boot.version>
+        <java.version>21</java.version>
+        <spring-boot.version>4.0.2</spring-boot.version>
         <modelmapper.version>3.2.6</modelmapper.version>
         <cloudinary-http5.version>2.3.2</cloudinary-http5.version>
         <mysql-connector-j.version>9.5.0</mysql-connector-j.version>
@@ -89,6 +89,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,11 +18,11 @@
         <spring-boot.version>4.0.2</spring-boot.version>
         <modelmapper.version>3.2.6</modelmapper.version>
         <cloudinary-http5.version>2.3.2</cloudinary-http5.version>
-        <mysql-connector-j.version>9.5.0</mysql-connector-j.version>
-        <postgresql.version>42.7.8</postgresql.version>
+        <mysql-connector-j.version>9.6.0</mysql-connector-j.version>
+        <postgresql.version>42.7.10</postgresql.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <jacoco.version>0.8.14</jacoco.version>
-        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <lombok.version>1.18.42</lombok.version>
         <sonar.organization>mark79-github</sonar.organization>
     </properties>

--- a/src/main/java/bg/softuni/invoice/config/SecurityConfiguration.java
+++ b/src/main/java/bg/softuni/invoice/config/SecurityConfiguration.java
@@ -27,7 +27,7 @@ public class SecurityConfiguration {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Bean
-    public SecurityFilterChain configureSecurity(HttpSecurity httpSecurity) throws Exception {
+    public SecurityFilterChain configureSecurity(HttpSecurity httpSecurity) {
         httpSecurity
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(csrf -> csrf.csrfTokenRepository(csrfTokenRepository()))

--- a/src/main/java/bg/softuni/invoice/config/SecurityConfiguration.java
+++ b/src/main/java/bg/softuni/invoice/config/SecurityConfiguration.java
@@ -1,7 +1,6 @@
 package bg.softuni.invoice.config;
 
 import lombok.AllArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -34,9 +33,16 @@ public class SecurityConfiguration {
                 .csrf(csrf -> csrf.csrfTokenRepository(csrfTokenRepository()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll()
-                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(
+                                "/css/**",
+                                "/js/**",
+                                "/images/**",
+                                "/webjars/**",
+                                "/favicon.ico"
+                        ).permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/user/register", "/user/login").anonymous()
+                        .requestMatchers("/log/**").hasRole("ROOT")
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/java/bg/softuni/invoice/service/ScheduleService.java
+++ b/src/main/java/bg/softuni/invoice/service/ScheduleService.java
@@ -1,14 +1,8 @@
 package bg.softuni.invoice.service;
 
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.scheduling.annotation.EnableAsync;
-
-@EnableAsync
 public interface ScheduleService {
-
-    @Async
     void deleteLogs();
 
-    @Async
     void changeStatus();
 }
+

--- a/src/main/java/bg/softuni/invoice/web/controller/HomeController.java
+++ b/src/main/java/bg/softuni/invoice/web/controller/HomeController.java
@@ -2,19 +2,23 @@ package bg.softuni.invoice.web.controller;
 
 import bg.softuni.invoice.web.annotation.PageTitle;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import java.security.Principal;
 
 @Controller
 public class HomeController {
 
     @GetMapping("/")
     @PageTitle("invoices")
-    public String index(Principal principal) {
+    public String index(Authentication authentication) {
 
-        if (principal != null) {
+        boolean isLoggedIn = authentication != null
+                && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken);
+
+        if (isLoggedIn) {
             return "home/home";
         }
 

--- a/src/main/java/bg/softuni/invoice/web/controller/UserController.java
+++ b/src/main/java/bg/softuni/invoice/web/controller/UserController.java
@@ -149,7 +149,7 @@ public class UserController {
 
     @GetMapping("/all")
     @PageTitle("User all")
-    @PreAuthorize("hasRole('ROLE_ROOT')")
+    @PreAuthorize("hasRole('ROOT')")
     public String allUsers(Model model) {
 
         List<UserViewModel> users = this.userService.getAllUsers()
@@ -172,7 +172,7 @@ public class UserController {
     }
 
     @PostMapping("/set-admin/{id}")
-    @PreAuthorize("hasRole('ROLE_ROOT')")
+    @PreAuthorize("hasRole('ROOT')")
     public String setAdminRole(@PathVariable String id) {
         this.userService.setAdmin(id);
 
@@ -180,7 +180,7 @@ public class UserController {
     }
 
     @PostMapping("/set-user/{id}")
-    @PreAuthorize("hasRole('ROLE_ROOT')")
+    @PreAuthorize("hasRole('ROOT')")
     public String setUserRole(@PathVariable String id) {
         this.userService.setUser(id);
 
@@ -188,7 +188,7 @@ public class UserController {
     }
 
     @PostMapping("/set-enabled/{id}")
-    @PreAuthorize("hasRole('ROLE_ROOT')")
+    @PreAuthorize("hasRole('ROOT')")
     public String setEnabled(@PathVariable String id) {
         this.userService.setUserEnabled(id);
 
@@ -196,7 +196,7 @@ public class UserController {
     }
 
     @PostMapping("/set-disabled/{id}")
-    @PreAuthorize("hasRole('ROLE_ROOT')")
+    @PreAuthorize("hasRole('ROOT')")
     public String setDisabled(@PathVariable String id) {
         this.userService.setUserDisabled(id);
 

--- a/src/main/java/bg/softuni/invoice/web/interceptor/LoggingInterceptor.java
+++ b/src/main/java/bg/softuni/invoice/web/interceptor/LoggingInterceptor.java
@@ -7,7 +7,7 @@ import bg.softuni.invoice.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.boot.security.autoconfigure.web.servlet.PathRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 

--- a/src/test/java/bg/softuni/invoice/repository/CompanyRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/CompanyRepositoryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/bg/softuni/invoice/repository/InvoiceRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/InvoiceRepositoryTest.java
@@ -9,7 +9,7 @@ import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/test/java/bg/softuni/invoice/repository/InvoiceRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/InvoiceRepositoryTest.java
@@ -84,7 +84,7 @@ class InvoiceRepositoryTest {
         List<Invoice> resultForUser2 = invoiceRepository.getAllByUser(user2);
 
         assertThat(resultForUser1).hasSize(1);
-        assertThat(resultForUser1.get(0).getTotalValue()).isEqualByComparingTo("200.00");
+        assertThat(resultForUser1.getFirst().getTotalValue()).isEqualByComparingTo("200.00");
         assertThat(resultForUser2).isEmpty();
     }
 

--- a/src/test/java/bg/softuni/invoice/repository/ItemRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/ItemRepositoryTest.java
@@ -5,7 +5,7 @@ import bg.softuni.invoice.model.enumerated.VatValue;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.math.BigDecimal;
 import java.util.Optional;

--- a/src/test/java/bg/softuni/invoice/repository/LogRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/LogRepositoryTest.java
@@ -5,7 +5,7 @@ import bg.softuni.invoice.model.entity.User;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/test/java/bg/softuni/invoice/repository/RoleRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/RoleRepositoryTest.java
@@ -4,7 +4,7 @@ import bg.softuni.invoice.model.entity.Role;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.util.Optional;
 

--- a/src/test/java/bg/softuni/invoice/repository/UserRepositoryTest.java
+++ b/src/test/java/bg/softuni/invoice/repository/UserRepositoryTest.java
@@ -4,7 +4,7 @@ import bg.softuni.invoice.model.entity.User;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
 import java.util.Optional;
 

--- a/src/test/java/bg/softuni/invoice/web/controller/CompanyControllerTest.java
+++ b/src/test/java/bg/softuni/invoice/web/controller/CompanyControllerTest.java
@@ -10,18 +10,20 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 
-@WebMvcTest(CompanyController.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 class CompanyControllerTest {
 
     @Autowired
@@ -43,7 +45,6 @@ class CompanyControllerTest {
     private ItemService itemService;
 
     @Test
-    @WithMockUser(roles = {"ADMIN"})
     void testAddConfirm_withValidInput_shouldRedirectToAll() throws Exception {
         CompanyAddBindingModel validModel = new CompanyAddBindingModel();
         validModel.setName("Valid Name");
@@ -59,7 +60,7 @@ class CompanyControllerTest {
         Mockito.when(companyService.getCompanyByUniqueIdentifier(validModel.getUniqueIdentifier())).thenReturn(null);
         Mockito.when(modelMapper.map(validModel, CompanyServiceModel.class)).thenReturn(serviceModel);
 
-        mockMvc.perform(post("/company/add")
+        mockMvc.perform(post("/company/add").with(user("test-admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .with(csrf())
                         .param("name", validModel.getName())
@@ -69,7 +70,6 @@ class CompanyControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"ADMIN"})
     void testAddConfirm_withNameConflict_shouldRedirectToAdd() throws Exception {
         CompanyAddBindingModel conflictingModel = new CompanyAddBindingModel();
         conflictingModel.setName("Existing Company");
@@ -81,7 +81,7 @@ class CompanyControllerTest {
 
         Mockito.when(companyService.getCompanyByName(conflictingModel.getName())).thenReturn(conflictingServiceModel);
 
-        mockMvc.perform(post("/company/add")
+        mockMvc.perform(post("/company/add").with(user("test-admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .with(csrf())
                         .param("name", conflictingModel.getName())
@@ -93,7 +93,6 @@ class CompanyControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"ADMIN"})
     void testAddConfirm_withUniqueIdentifierConflict_shouldRedirectToAdd() throws Exception {
         CompanyAddBindingModel conflictingModel = new CompanyAddBindingModel();
         conflictingModel.setName("New Company");
@@ -106,7 +105,7 @@ class CompanyControllerTest {
         Mockito.when(companyService.getCompanyByName(conflictingModel.getName())).thenReturn(null);
         Mockito.when(companyService.getCompanyByUniqueIdentifier(conflictingModel.getUniqueIdentifier())).thenReturn(conflictingServiceModel);
 
-        mockMvc.perform(post("/company/add")
+        mockMvc.perform(post("/company/add").with(user("test-admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .with(csrf())
                         .param("name", conflictingModel.getName())
@@ -118,9 +117,8 @@ class CompanyControllerTest {
     }
 
     @Test
-    @WithMockUser(roles = {"ADMIN"})
     void testAddConfirm_withValidationErrors_shouldRedirectToAdd() throws Exception {
-        mockMvc.perform(post("/company/add")
+        mockMvc.perform(post("/company/add").with(user("test-admin").roles("ADMIN"))
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .with(csrf())
                         .param("name", "")

--- a/src/test/java/bg/softuni/invoice/web/controller/HomeControllerTest.java
+++ b/src/test/java/bg/softuni/invoice/web/controller/HomeControllerTest.java
@@ -1,17 +1,15 @@
-package bg.softuni.invoice.controller;
+package bg.softuni.invoice.web.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -24,22 +22,22 @@ class HomeControllerTest {
     void index_shouldReturnCorrectView() throws Exception {
         this.mockMvc
                 .perform(get("/"))
+                .andExpect(status().isOk())
                 .andExpect(view().name("home/index"));
     }
 
     @Test
-    @WithMockUser
     void index_withAuthenticatedUserShouldReturnCorrectView() throws Exception {
         this.mockMvc
-                .perform(get("/"))
+                .perform(get("/").with(user("test-user").roles("USER")))
+                .andExpect(status().isOk())
                 .andExpect(view().name("home/home"));
     }
 
     @Test
-    @WithMockUser()
     void home_shouldReturnCorrectView() throws Exception {
         this.mockMvc
-                .perform(get("/home").with(csrf()))
+                .perform(get("/home").with(user("test-user").roles("USER")))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/invoice/all"));
     }
@@ -48,14 +46,15 @@ class HomeControllerTest {
     void index_withNullPrincipal_shouldReturnIndexView() throws Exception {
         this.mockMvc
                 .perform(get("/"))
+                .andExpect(status().isOk())
                 .andExpect(view().name("home/index"));
     }
 
     @Test
-    @WithMockUser
     void index_withAuthenticatedPrincipal_shouldReturnHomeView() throws Exception {
         this.mockMvc
-                .perform(get("/"))
+                .perform(get("/").with(user("test-user").roles("USER")))
+                .andExpect(status().isOk())
                 .andExpect(view().name("home/home"));
     }
 }

--- a/src/test/java/bg/softuni/invoice/web/controller/LogControllerTest.java
+++ b/src/test/java/bg/softuni/invoice/web/controller/LogControllerTest.java
@@ -1,16 +1,15 @@
-package bg.softuni.invoice.controller;
+package bg.softuni.invoice.web.controller;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -20,10 +19,10 @@ class LogControllerTest {
     private MockMvc mockMvc;
 
     @Test
-    @WithMockUser(roles = {"ROOT"})
     void all_shouldReturnCorrectView() throws Exception {
         this.mockMvc
-                .perform(get("/log/all").with(csrf()))
+                .perform(get("/log/all").with(user("test-root").roles("ROOT")))
+                .andExpect(status().isOk())
                 .andExpect(view().name("log/all"));
     }
 }

--- a/src/test/java/bg/softuni/invoice/web/controller/UserControllerTest.java
+++ b/src/test/java/bg/softuni/invoice/web/controller/UserControllerTest.java
@@ -1,4 +1,4 @@
-package bg.softuni.invoice.controller;
+package bg.softuni.invoice.web.controller;
 
 import bg.softuni.invoice.repository.UserRepository;
 import bg.softuni.invoice.service.RoleService;
@@ -6,12 +6,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
@@ -45,10 +45,9 @@ class UserControllerTest {
     }
 
     @Test
-    @WithMockUser
     void login_withLoggedInUserShouldReturnErrorView() throws Exception {
         this.mockMvc
-                .perform(get("/user/login"))
+                .perform(get("/user/login").with(user("test-user").roles("USER")))
                 .andExpect(status().is4xxClientError())
                 .andExpect(forwardedUrl("/error"));
     }
@@ -64,7 +63,8 @@ class UserControllerTest {
     @Test
     void register_registerSuccessfullyRedirect() throws Exception {
         this.mockMvc
-                .perform(post("/user/register").with(csrf())
+                .perform(post("/user/register")
+                        .with(csrf())
                         .param("username", "admin@admin.com")
                         .param("firstName", "Admin")
                         .param("lastName", "Admin")
@@ -80,7 +80,8 @@ class UserControllerTest {
     @Test
     void register_whenBindingResultHasErrorsRedirect() throws Exception {
         this.mockMvc
-                .perform(post("/user/register").with(csrf())
+                .perform(post("/user/register")
+                        .with(csrf())
                         .param("username", "")
                         .param("firstName", "")
                         .param("lastName", "")
@@ -95,7 +96,8 @@ class UserControllerTest {
     void register_whenUsernameAlreadyExistsRedirect() throws Exception {
 
         this.mockMvc
-                .perform(post("/user/register").with(csrf())
+                .perform(post("/user/register")
+                        .with(csrf())
                         .param("username", "admin@admin.com")
                         .param("firstName", "Admin")
                         .param("lastName", "Admin")
@@ -104,7 +106,8 @@ class UserControllerTest {
                 );
 
         this.mockMvc
-                .perform(post("/user/register").with(csrf())
+                .perform(post("/user/register")
+                        .with(csrf())
                         .param("username", "admin@admin.com")
                         .param("firstName", "Test")
                         .param("lastName", "Test")
@@ -116,30 +119,26 @@ class UserControllerTest {
     }
 
     @Test
-    @WithMockUser
     void register_withLoggedInUserShouldReturnErrorView() throws Exception {
         this.mockMvc
-                .perform(get("/user/register").with(csrf()))
+                .perform(get("/user/register").with(user("test-user").roles("USER")))
                 .andExpect(status().is4xxClientError())
                 .andExpect(forwardedUrl("/error"));
     }
 
     @Test
-    @WithMockUser(roles = "ROOT")
     void all_withLoggedInRootUserShouldReturnCorrectView() throws Exception {
         this.mockMvc
-                .perform(get("/user/all").with(csrf()))
+                .perform(get("/user/all").with(user("test-root").roles("ROOT")))
                 .andExpect(model().attributeExists("users"))
                 .andExpect(model().attributeExists("comparator"))
                 .andExpect(view().name("user/all"));
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
     void all_withLoggedInAdminOrUserShouldReturnCorrectViewAdmin() throws Exception {
         this.mockMvc
-                .perform(get("/user/all").with(csrf()))
+                .perform(get("/user/all").with(user("test-admin").roles("ADMIN")))
                 .andExpect(view().name("error"));
     }
-
 }

--- a/src/test/java/bg/softuni/invoice/web/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/bg/softuni/invoice/web/error/GlobalExceptionHandlerTest.java
@@ -2,8 +2,8 @@ package bg.softuni.invoice.web.error;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
@@ -11,7 +11,7 @@ import org.springframework.ui.Model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -28,7 +28,7 @@ class GlobalExceptionHandlerTest {
     void handleAllErrors_whenFailureUrl_redirectsToLoginPage() throws Exception {
         mockMvc.perform(get("/a-nonexistent-url"))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrlPattern("**/user/login"));
+                .andExpect(redirectedUrl("/user/login"));
     }
 
     @Test

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=17
+java.runtime.version=21


### PR DESCRIPTION
- Update dependency versions in pom.xml.
- Update GitHub Actions workflow to use JDK 21.
- Update Dockerfile to use the Java 21 alpine image.
- Set system properties to require Java 21.
- Replace WithMockUser annotations with MockMvc user setup.
- Use Authentication instead of Principal in HomeController.
- Restrict /log/** endpoint to ROOT role only.
- Remove unnecessary Async and EnableAsync annotations.
- Fix incorrect annotations in test files to match Spring Boot 4 changes.
